### PR TITLE
Optional "answer-explanation" field in json

### DIFF
--- a/app/src/main/java/com/ryanwarsaw/coach_erevu/activity/QuizActivity.java
+++ b/app/src/main/java/com/ryanwarsaw/coach_erevu/activity/QuizActivity.java
@@ -81,6 +81,7 @@ public class QuizActivity extends AppCompatActivity implements View.OnClickListe
         WrongAnswerFragment fragment = new WrongAnswerFragment();
         Bundle args = new Bundle();
         args.putString("correct_answer", question.getAnswers().get(question.getCorrectAnswerIndex() - 1));
+        args.putString("answer_explanation", question.getAnswerExplanation());
         fragment.setArguments(args);
         fragment.show(getFragmentManager(), "wrong_answer_dialog");
       }

--- a/app/src/main/java/com/ryanwarsaw/coach_erevu/fragment/WrongAnswerFragment.java
+++ b/app/src/main/java/com/ryanwarsaw/coach_erevu/fragment/WrongAnswerFragment.java
@@ -14,8 +14,16 @@ public class WrongAnswerFragment extends DialogFragment {
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
     AlertDialog.Builder builder = new Builder(getActivity());
-    builder.setMessage(getResources().getString(R.string.wrong_answer_dialog) +
-      getArguments().getString("correct_answer") + "\"")
+    String dialogString = getResources().getString(R.string.wrong_answer_dialog) +
+                          getArguments().getString("correct_answer") + ".\"";
+
+    String answerExplanation = getArguments().getString("answer_explanation");
+
+    if (answerExplanation != null) {
+      dialogString = dialogString + " " + answerExplanation;
+    }
+
+    builder.setMessage(dialogString)
       .setPositiveButton(R.string.okay_button, new OnClickListener() {
         @Override
         public void onClick(DialogInterface dialog, int which) {

--- a/app/src/main/java/com/ryanwarsaw/coach_erevu/model/Question.java
+++ b/app/src/main/java/com/ryanwarsaw/coach_erevu/model/Question.java
@@ -21,4 +21,7 @@ public class Question {
 
   @SerializedName("correct-answer")
   public int correctAnswerIndex;
+
+  @SerializedName("answer-explanation")
+  public String answerExplanation;
 }

--- a/app/src/main/res/raw/content.json
+++ b/app/src/main/res/raw/content.json
@@ -100,7 +100,8 @@
             "meaningless",
             "whatever is on the clock"
           ],
-          "correct-answer": 2
+          "correct-answer": 2,
+          "answer-explanation": "If you are human, you must obey the arrow of time."
         },
         {
           "question": "How does time make your life better?",


### PR DESCRIPTION
Added logic to see if answer-explanation exists in json so that content.json can also have a little explanation of why the correct answer is what it is, if the user picked the wrong one.

@lauradereynal I added this so that you and the team *can* add explanations for quiz answers, but it's by no means necessary. Just something to play with if you want.

Fixes #32