### PR TITLE
Remove strict requirement that topic contain both a quiz and video

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /build
 /captures
 .externalNativeBuild
+app/src/main/assets/

--- a/app/src/main/java/com/ryanwarsaw/coach_erevu/activity/ActionActivity.java
+++ b/app/src/main/java/com/ryanwarsaw/coach_erevu/activity/ActionActivity.java
@@ -59,7 +59,7 @@ public class ActionActivity extends AppCompatActivity {
     videoButton.setOnClickListener(new View.OnClickListener() {
       public void onClick(View view) {
         final Intent intent = new Intent(ActionActivity.this, VideoActivity.class);
-        intent.putExtra("video_name", topic.getVideoName());
+        intent.putExtra("topic", gson.toJson(topic));
         intent.putExtra("preferences", gson.toJson(preferences));
 
         MainActivity.getLoggingHandler().write(ActionActivity.this.getClass().getSimpleName(),

--- a/app/src/main/java/com/ryanwarsaw/coach_erevu/activity/VideoActivity.java
+++ b/app/src/main/java/com/ryanwarsaw/coach_erevu/activity/VideoActivity.java
@@ -21,10 +21,12 @@ import com.google.android.exoplayer2.upstream.DataSource.Factory;
 import com.google.android.exoplayer2.upstream.DataSpec;
 import com.google.android.exoplayer2.upstream.FileDataSource;
 import com.google.android.exoplayer2.upstream.FileDataSource.FileDataSourceException;
+import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.ryanwarsaw.coach_erevu.MainActivity;
 import com.ryanwarsaw.coach_erevu.R;
 import com.ryanwarsaw.coach_erevu.model.Preferences;
+import com.ryanwarsaw.coach_erevu.model.Topic;
 
 import java.io.File;
 
@@ -37,8 +39,11 @@ public class VideoActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_video);
 
-    final Preferences preferences = new GsonBuilder().create()
-            .fromJson(getIntent().getStringExtra("preferences"), Preferences.class);
+    final Gson gson = new GsonBuilder().create();
+
+    final Preferences preferences = gson.fromJson(
+            getIntent().getStringExtra("preferences"), Preferences.class);
+    final Topic topic = gson.fromJson(getIntent().getStringExtra("topic"), Topic.class);
 
     exoPlayer = ExoPlayerFactory.newSimpleInstance(this, new DefaultTrackSelector());
 
@@ -58,7 +63,7 @@ public class VideoActivity extends AppCompatActivity {
       }
     });
 
-    exoPlayer.prepare(buildVideoSource(getIntent().getStringExtra("video_name")));
+    exoPlayer.prepare(buildVideoSource(topic.getVideoName()));
     exoPlayer.setPlayWhenReady(true);
   }
 

--- a/app/src/main/java/com/ryanwarsaw/coach_erevu/adapter/TopicAdapter.java
+++ b/app/src/main/java/com/ryanwarsaw/coach_erevu/adapter/TopicAdapter.java
@@ -2,8 +2,10 @@ package com.ryanwarsaw.coach_erevu.adapter;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -16,6 +18,8 @@ import com.ryanwarsaw.coach_erevu.CommonUtilities;
 import com.ryanwarsaw.coach_erevu.MainActivity;
 import com.ryanwarsaw.coach_erevu.R;
 import com.ryanwarsaw.coach_erevu.activity.ActionActivity;
+import com.ryanwarsaw.coach_erevu.activity.QuizActivity;
+import com.ryanwarsaw.coach_erevu.activity.VideoActivity;
 import com.ryanwarsaw.coach_erevu.model.Category;
 import com.ryanwarsaw.coach_erevu.model.Preferences;
 import com.ryanwarsaw.coach_erevu.model.Topic;
@@ -51,15 +55,39 @@ public class TopicAdapter extends ArrayAdapter<Topic> {
       public void onClick(View view) {
         final Button button = view.findViewById(R.id.menu_button);
         final Topic topic = category.findTopicByTitle((String) button.getText());
-        final Intent intent = new Intent(context, ActionActivity.class);
         final Gson gson = new GsonBuilder().create();
 
         MainActivity.getLoggingHandler().write(TopicAdapter.this.getClass()
                 .getSimpleName(), "TOPIC_SELECTED", topic.getTitle());
-        intent.putExtra("topic", gson.toJson(topic));
-        intent.putExtra("preferences", gson.toJson(preferences));
 
-        context.startActivity(intent);
+        final Bundle args = new Bundle();
+        args.putString("topic", gson.toJson(topic));
+        args.putString("preferences", gson.toJson(preferences));
+
+        // If this topic contains a quiz and video activity, send them to the action selection menu.
+        if (topic.getQuestions() != null && topic.getVideoName() != null) {
+          final Intent actionIntent = new Intent(context, ActionActivity.class);
+          actionIntent.putExtras(args);
+          context.startActivity(actionIntent);
+        } else {
+          // If the topic only contains a quiz then launch user directly into quiz activity.
+          if (topic.getQuestions() != null && topic.getQuestions().size() > 0) {
+            MainActivity.getLoggingHandler().write(TopicAdapter.this.getClass().getSimpleName(),
+                    "BUTTON_QUIZ_PRESS", topic.getTitle());
+            final Intent quizIntent = new Intent(context, QuizActivity.class);
+            quizIntent.putExtras(args);
+            context.startActivity(quizIntent);
+          }
+
+          // If the topic only contains a video then launch user directly into video activity.
+          if (topic.getVideoName() != null) {
+            MainActivity.getLoggingHandler().write(TopicAdapter.this.getClass().getSimpleName(),
+                    "BUTTON_VIDEO_PRESS", topic.getTitle());
+            final Intent videoIntent = new Intent(context, VideoActivity.class);
+            videoIntent.putExtras(args);
+            context.startActivity(videoIntent);
+          }
+        }
       }
     });
 


### PR DESCRIPTION
TLDR; If a topic doesn't contain both, rather than sending you to the "action menu" it'll automatically open whatever action type is present. This allows you to skip an unnecessary menu.