### PR TITLE
Fixes #191: Custom end-of-quiz popup message for introduction quiz

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
     applicationId "com.ryanwarsaw.coach_erevu"
     minSdkVersion 19
     targetSdkVersion 28
-    versionCode 5
-    versionName "3.1"
+    versionCode 6
+    versionName "3.2"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
   }
 

--- a/app/src/main/java/com/ryanwarsaw/coach_erevu/activity/QuizActivity.java
+++ b/app/src/main/java/com/ryanwarsaw/coach_erevu/activity/QuizActivity.java
@@ -97,6 +97,7 @@ public class QuizActivity extends AppCompatActivity {
     MainActivity.getLoggingHandler().write(getClass().getSimpleName(), "QUIZ_QUESTION", question.getQuestion());
   }
 
+  // TODO: Review the text here.
   public void advanceToNextQuestion() {
     if (currentIndex + 1 < topic.getQuestions().size()) {
       // Inflate the next question, and replace the existing fragment.
@@ -105,7 +106,11 @@ public class QuizActivity extends AppCompatActivity {
       // Build the dialog to inform the user they've finished the quiz, and present it to them.
       AlertDialog alertDialog = new AlertDialog.Builder(this).create();
       alertDialog.setTitle(getResources().getString(R.string.quiz_end_title));
-      alertDialog.setMessage(getResources().getString(R.string.quiz_end));
+
+      // If topic has "end-of-quiz" property set use that, otherwise pull default from string resource.
+      alertDialog.setMessage(topic.getEndOfQuiz() != null ?
+              topic.getEndOfQuiz() : getResources().getString(R.string.quiz_end));
+
       alertDialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
         public void onDismiss(DialogInterface dialog) {
           finish();

--- a/app/src/main/java/com/ryanwarsaw/coach_erevu/activity/QuizActivity.java
+++ b/app/src/main/java/com/ryanwarsaw/coach_erevu/activity/QuizActivity.java
@@ -97,7 +97,6 @@ public class QuizActivity extends AppCompatActivity {
     MainActivity.getLoggingHandler().write(getClass().getSimpleName(), "QUIZ_QUESTION", question.getQuestion());
   }
 
-  // TODO: Review the text here.
   public void advanceToNextQuestion() {
     if (currentIndex + 1 < topic.getQuestions().size()) {
       // Inflate the next question, and replace the existing fragment.

--- a/app/src/main/java/com/ryanwarsaw/coach_erevu/model/Topic.java
+++ b/app/src/main/java/com/ryanwarsaw/coach_erevu/model/Topic.java
@@ -24,6 +24,9 @@ public class Topic {
   @SerializedName("video")
   private String videoName;
 
+  @SerializedName("end-of-quiz")
+  private String endOfQuiz;
+
   @SerializedName("questions")
   private List<Question> questions;
 }

--- a/app/src/main/res/raw/content.json
+++ b/app/src/main/res/raw/content.json
@@ -15,6 +15,7 @@
           "title": "Intangamarara",
           "color": "#45b39d",
           "video": "introduction.mp4",
+          "end-of-quiz": "Mwakoze gukorera hamwe aka kabazo nk’umurwi!",
           "questions": [
             {
               "question": "Ni ikihe ciyumviro rusangi cawe kijanye n'ugukunda iyi reresi?",


### PR DESCRIPTION
Adds an optional property `end-of-quiz` to Topic that allows you to customize the pop-up you are presented with when finishing a quiz. Otherwise it'll default to `quiz_end` in app string resources.